### PR TITLE
add command overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Recommended for use with [aws-vault][] for authentication.
 ## Usage
 
 ```bash
-$ aws-vault exec myprofile -- ecs-run-task --file examples/helloworld/taskdefinition.json
+$ aws-vault exec myprofile -- ecs-run-task --file examples/helloworld/taskdefinition.json echo "Hello from Docker!"
 
 Hello from Docker!
 ...

--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ func main() {
 			if ec, ok := err.(cli.ExitCoder); ok {
 				return ec
 			}
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 		return nil
@@ -87,14 +87,14 @@ func main() {
 
 	err := app.Run(os.Args)
 	if err != nil {
-		log.Println(err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 }
 
 func requireFlagValue(ctx *cli.Context, name string) {
 	if ctx.String(name) == "" {
-		fmt.Printf("ERROR: Required flag %q isn't set\n\n", name)
+		fmt.Fprintf(os.Stderr, "ERROR: Required flag %q isn't set\n\n", name)
 		cli.ShowAppHelpAndExit(ctx, 1)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func main() {
 		cli.StringFlag{
 			Name:  "service, s",
 			Value: "",
-			Usage: "[command override]",
+			Usage: "service to replace cmd for",
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ func main() {
 	app.Name = "ecs-run-task"
 	app.Usage = "run a once-off task on ECS and tail the output from cloudwatch"
 	app.UsageText = "ecs-run-task [options] [command override]"
+	app.Version = Version
 
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{
@@ -84,7 +85,11 @@ func main() {
 		return nil
 	}
 
-	app.Run(os.Args)
+	err := app.Run(os.Args)
+	if err != nil {
+		log.Println(err.Error())
+		os.Exit(1)
+	}
 }
 
 func requireFlagValue(ctx *cli.Context, name string) {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -100,7 +100,9 @@ func (r *Runner) Run() error {
 				if len(taskDefinitionInput.ContainerDefinitions) != 1 {
 					return fmt.Errorf("no service provided for override and cant determine default service with %d container definitions", len(taskDefinitionInput.ContainerDefinitions))
 				}
+
 				override.Service = *taskDefinitionInput.ContainerDefinitions[0].Name
+				log.Printf("Assuming override applies to '%s'", override.Service)
 			}
 
 			for _, command := range override.Command {
@@ -120,7 +122,7 @@ func (r *Runner) Run() error {
 	log.Printf("Running task %s", taskDefinition)
 	runResp, err := svc.RunTask(runTaskInput)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to run task: %d", err.Error())
 	}
 
 	taskARNs := []*string{}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -96,6 +96,13 @@ func (r *Runner) Run() error {
 		if len(override.Command) > 0 {
 			cmds := []*string{}
 
+			if override.Service == "" {
+				if len(taskDefinitionInput.ContainerDefinitions) != 1 {
+					return fmt.Errorf("no service provided for override and cant determine default service with %d container definitions", len(taskDefinitionInput.ContainerDefinitions))
+				}
+				override.Service = *taskDefinitionInput.ContainerDefinitions[0].Name
+			}
+
 			for _, command := range override.Command {
 				cmds = append(cmds, aws.String(command))
 			}

--- a/runner/watcher.go
+++ b/runner/watcher.go
@@ -79,7 +79,7 @@ func (lw *logWatcher) Watch(ctx context.Context) error {
 	var after int64
 	var err error
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	for {


### PR DESCRIPTION
Often when running a one off task you want to specify the command to run.

eg for running migrations:
```bash
ecs-run-task --file taskdef.yml migrate
```

if there are multiple containers running you will need to specify which one with --service
```bash
ecs-run-task --file taskdef.yml --service app migrate
```