### PR TITLE
Wait longer for streams to appear

### DIFF
--- a/runner/watcher.go
+++ b/runner/watcher.go
@@ -41,7 +41,7 @@ func (lw *logWatcher) printEventsAfter(ts int64, c context.CancelFunc) (int64, e
 	log.Printf("Printing events after %d", ts)
 
 	// sometimes the stream takes a while to appear
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 30; i++ {
 		streams, err = lw.findStreams()
 		if err != nil || len(streams) == 0 {
 			log.Printf("Log stream hasn't started yet")


### PR DESCRIPTION
Occasionally log streams aren't visible for more than 20s. No harm in bumping it to a minute right?