### PR TITLE
Fixing missing logs when container exit code is non-zero

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -214,7 +214,8 @@ func (r *Runner) Run() error {
 	log.Printf("Waiting for exitcode")
 	if err := <-errs; err != nil {
 		log.Printf("Error from ch: %#v", err)
-		// If the error is not an exit error, stop everything
+		// If the error is an exitError, continue processing so that
+		// all of the logs are streamed
 		_, ok := err.(*exitError)
 		if(!ok) {
 			cancel()

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -214,14 +214,18 @@ func (r *Runner) Run() error {
 	log.Printf("Waiting for exitcode")
 	if err := <-errs; err != nil {
 		log.Printf("Error from ch: %#v", err)
-		cancel()
-		return err
+		// If the error is not an exit error, stop everything
+		_, ok := err.(*exitError)
+		if(!ok) {
+			cancel()
+			return err
+		}
 	}
 
 	log.Printf("Waiting for logging to finish")
 	wg.Wait()
 
-	return nil
+	return err
 }
 
 func logStreamName(streamPrefix string, task *ecs.Task, container *ecs.Container) string {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -216,8 +216,7 @@ func (r *Runner) Run() error {
 		log.Printf("Error from ch: %#v", err)
 		// If the error is an exitError, continue processing so that
 		// all of the logs are streamed
-		_, ok := err.(*exitError)
-		if(!ok) {
+		if _, isExit := err.(*exitError); !isExit {
 			cancel()
 			return err
 		}


### PR DESCRIPTION
I ran into what is seemingly a race condition if a container exits with non-zero exit code.

The `exitError` sent to the `errs` channel on line 173 of runner.go sometimes gets consumed and causes the program to exit before it actually streams all of the logs -- so you often can't see why the task has had a non-zero exit code.

This updates the `errs` channel handing, so that in the case of an `exitError` it'll still waits for logs to finish before exiting, but `Runner.Run` will still return an error.

Thanks for this lovely piece of software!