### PR TITLE
Fix log waiting busy loop

### DIFF
--- a/runner/watcher.go
+++ b/runner/watcher.go
@@ -41,12 +41,14 @@ func (lw *logWatcher) printEventsAfter(ts int64, c context.CancelFunc) (int64, e
 	log.Printf("Printing events after %d", ts)
 
 	// sometimes the stream takes a while to appear
-	log.Printf("Waiting for log stream to start...")
-	for i := 0; i < 300; i++ {
+	log.Print("Waiting for log stream to start...")
+	start := time.Now()
+	for time.Since(start) < 10*time.Minute {
 		streams, err = lw.findStreams()
-		if err != nil || len(streams) == 0 {
-			time.Sleep(time.Second * 2)
+		if len(streams) > 0 {
+			break
 		}
+		time.Sleep(time.Second * 2)
 	}
 
 	if err != nil {


### PR DESCRIPTION
Note: this is a follow on from #9 

We've been receiving a few throttling errors from AWS:

```text
2018/04/19 05:19:56 Log group ecs-task-runner exists
2018/04/19 05:19:56 Setting tasks to use log group ecs-task-runner
2018/04/19 05:19:56 Registering a task for something-worker
2018/04/19 05:19:56 Assuming override applies to 'something-worker'
2018/04/19 05:19:56 Running task something-worker:86
2018/04/19 05:19:57 Watching ecs-task-runner/run_task_11303614/something-worker/59f5192a-6f0f-4f43-9e8f-fc31346b36cb
2018/04/19 05:19:57 Waiting for exitcode
2018/04/19 05:19:58 Printing events after 0
2018/04/19 05:19:58 Waiting for log stream to start...
2018/04/19 05:22:21 Error from ch: &awserr.requestError{awsError:(*awserr.baseError)(0xc4200a8840), statusCode:400, requestID:"a288997f-4391-11e8-867e-33dc3699dff5"}
ThrottlingException: Rate exceeded
	status code: 400, request id: a288997f-4391-11e8-867e-33dc3699dff5
```

Looking at where I assume the problem is it seems that the loop that checks for the log streams has no `break` condition: it will always check 300 times (recently up from 30) for log streams to appear. If the log streams _do_ appear (`err == nil` and `len(streams) > 0`) it will then check again immediately. Assumingly it will continue to hit the API as fast as it can until it starts receiving throttling errors and those then cause everything else to fail.

This extracts the stream waiting logic out to make it more obvious. It also uses context and cancellation to be more clear about how long this will wait on API responses.

I've also bumped the wait time down from >10 minutes to 5 minutes.