### PR TITLE
Add support for environment variables

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,6 +61,10 @@ func main() {
 			Name:  "subnet",
 			Usage: "Subnet to launch task in (required for FARGATE). Can be specified multiple times",
 		},
+		cli.StringSliceFlag{
+			Name:  "env, e",
+			Usage: "An environment variable to add in the form `KEY=value` or `KEY` (shorthand for `KEY=$KEY` to pass through an env var from the current host). Can be specified multiple times",
+		},
 	}
 
 	app.Action = func(ctx *cli.Context) error {
@@ -82,6 +86,7 @@ func main() {
 		r.Fargate = ctx.Bool("fargate")
 		r.SecurityGroups = ctx.StringSlice("security-group")
 		r.Subnets = ctx.StringSlice("subnet")
+		r.Environment = ctx.StringSlice("env")
 
 		if args := ctx.Args(); len(args) > 0 {
 			r.Overrides = append(r.Overrides, runner.Override{

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -1,0 +1,76 @@
+package runner
+
+import "testing"
+
+func TestAWSKeyValuePairForEnvEmpty(t *testing.T) {
+	lookupEnv := func(key string) (string, bool) {
+		t.Fatal("expected no calls to getenv")
+		return "", false
+	}
+
+	kvp, err := awsKeyValuePairForEnv(lookupEnv, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %q", err.Error())
+	}
+	if len(kvp) != 0 {
+		t.Fatalf("Expected no key/value pairs, got %d of them", len(kvp))
+	}
+}
+
+func TestAWSKeyValuePairForEnv(t *testing.T) {
+	currentEnv := map[string]string{
+		"HOSTNAME": "my-hostname",
+		"EMPTY":    "",
+	}
+	lookupEnv := func(key string) (string, bool) {
+		v, ok := currentEnv[key]
+		return v, ok
+	}
+
+	kvp, err := awsKeyValuePairForEnv(lookupEnv, []string{
+		"HOSTNAME",
+		"EMPTY",
+		"PROVIDED=some-provided-value",
+	})
+	if err != nil {
+		t.Fatal("Unexpected error: " + err.Error())
+	}
+	expected := map[string]string{
+		"HOSTNAME": "my-hostname",
+		"EMPTY":    "",
+		"PROVIDED": "some-provided-value",
+	}
+
+	if len(kvp) != len(expected) {
+		t.Fatalf("Unexpected number of key value pairs. Expected %d, actual %d", len(expected), len(kvp))
+	}
+
+	for _, pair := range kvp {
+		name := *pair.Name
+		value := *pair.Value
+		expectedValue := expected[name]
+		if value != expectedValue {
+			t.Fatalf("Bad value for key %q. Expected %q, actual %q. Could be missing or could be duplicated", name, expectedValue, value)
+		}
+
+		// to ensure we aren't just getting the same one over and over again
+		delete(expected, name)
+	}
+}
+
+func TestAWSKeyValuePairForEnvMissing(t *testing.T) {
+	lookupEnv := func(key string) (string, bool) {
+		return "", false
+	}
+
+	_, err := awsKeyValuePairForEnv(lookupEnv, []string{
+		"MISSING_VALUE",
+	})
+
+	if err == nil {
+		t.Fatal("Expected an error, got nil")
+	}
+	if err.Error() != `missing environment variable "MISSING_VALUE"` {
+		t.Fatalf("bad error message returned: %q", err.Error())
+	}
+}


### PR DESCRIPTION
Related issue: #11

Sometimes you'll want the task being run to have some environment variables passed through to it that aren't already in the task definition. This adds a `--env` or `-e` command line flag to pass in environment variables:

```shell
$ ecs-run-task \
    --file my-task-definition.yml \
    --cluster my-cluster \
    --env KEY=value \
    --env KEY_FROM_HOST \
    my-command-to-run
```