### PR TITLE
Pass non-zero exit codes back to ecs-run-task

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -225,7 +225,7 @@ func (r *Runner) Run() error {
 	}
 
 	log.Printf("Waiting for exitcode")
-	if err := <-errs; err != nil {
+	if err = <-errs; err != nil {
 		log.Printf("Error from ch: %#v", err)
 		// If the error is an exitError, continue processing so that
 		// all of the logs are streamed


### PR DESCRIPTION
I found that a non-zero exit code from the remote command resulted in an exit code of zero from `ecs-run-task`. I am assuming that is an error.

```
$ ecs-run-task --debug --file task.yml --cluster mycluster false
...
2018/05/07 00:07:29 Waiting for exitcode
2018/05/07 00:07:30 Printing events after 0
2018/05/07 00:07:30 Waiting for log stream to start...
2018/05/07 00:08:37 Error from ch: &runner.exitError{error:(*errors.errorString)(0xc42033acf0), exitCode:1}
2018/05/07 00:08:37 Waiting for logging to finish
2018/05/07 00:09:17 Finished: Container d3e3a828-8e69-4cf9-9ef0-39224d8882f9 exited with 1
$ echo $?
0
```

Here is the related piece of code: https://github.com/buildkite/ecs-run-task/blob/1b02e0ba7d550f349f6d287f228178174a9f126b/runner/runner.go#L227-L241

The shadowing of `err` inside this `if` block results in `exitError`s always returning `nil` from this function.

This patch removes the second `err` instance so the `err` pulled from the channel is returned out of this function.

```
$ ecs-run-task --debug --file task.yml --cluster mycluster false
...
2018/05/07 11:14:41 Waiting for exitcode
2018/05/07 11:14:42 Printing events after 0
2018/05/07 11:14:42 Waiting for log stream to start...
2018/05/07 11:16:10 Error from ch: &runner.exitError{error:(*errors.errorString)(0xc4203a85a0), exitCode:1}
2018/05/07 11:16:10 Waiting for logging to finish
2018/05/07 11:16:59 Finished: Container 2ad89df4-01a7-4d24-a19f-23b66d2b5c57 exited with 1
Container mycontainer exited with 1
$ echo $?
1
```