### PR TITLE
handle nil container Reason fixes #26

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -275,7 +275,11 @@ func writeContainerFinishedMessage(ctx context.Context, w *logWriter, task *ecs.
 		return fmt.Errorf("expected container to be STOPPED, got %s", *container.LastStatus)
 	}
 	if container.ExitCode == nil {
-		return errors.New(*container.Reason)
+		if container.Reason != nil {
+			return errors.New(*container.Reason)
+		} else {
+			return errors.New(*task.StoppedReason)
+		}
 	}
 	return w.WriteString(ctx, fmt.Sprintf(
 		"Container %s exited with %d",


### PR DESCRIPTION
I see there is a branch called `handle-nil-reason. I handled it a little differently, but looking at that previously made branch, maybe there should be a separate `writeTaskFinishedMessage` message that is called after this loop https://github.com/buildkite/ecs-run-task/blob/master/runner/runner.go#L230 ?