### PR TITLE
missing family field causes panic

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -78,7 +78,7 @@ func (r *Runner) Run(ctx context.Context) error {
 
 	svc := ecs.New(sess)
 
-	log.Printf("Registering a task for %s", *taskDefinitionInput.Family)
+	log.Printf("Registering a task for %v", taskDefinitionInput.Family)
 	resp, err := svc.RegisterTaskDefinition(taskDefinitionInput)
 	if err != nil {
 		return err


### PR DESCRIPTION
missing family field in task definition field causes a nil pointer
derefence panic when logging

we can use a value here instead of a pointer and now get a debug
message: `Registering a task for <nil>` and the missing field error from
the aws sdk