### PR TITLE
fix region error. fix env vars not propagated to task if -s not provided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /build/*
+__debug_bin
+.vscode/

--- a/go.mod
+++ b/go.mod
@@ -16,3 +16,5 @@ require (
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v2 v2.2.1 // indirect
 )
+
+go 1.13

--- a/main.go
+++ b/main.go
@@ -75,6 +75,10 @@ func main() {
 			Value: 1,
 			Usage: "Number of tasks to run",
 		},
+		cli.StringFlag{
+			Name:  "region, r",
+			Usage: "Reion",
+		},
 		cli.BoolFlag{
 			Name:  "deregister",
 			Usage: "Deregister task definition once done",
@@ -103,6 +107,10 @@ func main() {
 		r.Environment = ctx.StringSlice("env")
 		r.Count = ctx.Int64("count")
 		r.Deregister = ctx.Bool("deregister")
+
+		if r.Region == "" {
+			r.Region = ctx.String("region")
+		}
 
 		if ctx.Bool("inherit-env") {
 			for _, env := range os.Environ() {


### PR DESCRIPTION
- AWS Region had to be provided by AWS_REGION env var. Now -r flag can be specified.
- "-e" flag was not honored if "-s" flag was not provided. Now env vars provided with "-e" are propagated to the task as overrides, regardless of the "-s" flag.
- Lint errors
- added some common values to .gitignore