### PR TITLE
Follow the next token when pages of results returned

### DIFF
--- a/runner/cloudwatch.go
+++ b/runner/cloudwatch.go
@@ -54,7 +54,7 @@ func (lw *logWaiter) streamExists() (bool, error) {
 				// return early if we match the log stream
 				if *stream.LogStreamName == lw.LogStreamName {
 					exists = true
-					return true
+					return false
 				}
 			}
 			return !lastPage

--- a/runner/cloudwatch.go
+++ b/runner/cloudwatch.go
@@ -57,7 +57,7 @@ func (lw *logWaiter) streamExists() (bool, error) {
 					return true
 				}
 			}
-			return lastPage
+			return !lastPage
 		})
 
 	return exists, err
@@ -212,7 +212,7 @@ func (lw *logWatcher) printEventsAfter(ctx context.Context, ts int64) (int64, er
 					ts = *event.Timestamp
 				}
 			}
-			return lastPage
+			return !lastPage
 		})
 	if err != nil {
 		log.Printf("Printed %d events in %v", count, time.Now().Sub(t))


### PR DESCRIPTION
The AWS SDK Pages functions iterate over pages of results automatically using the NextToken returned from AWS API. However in order to allow the function to iterate correctly, you need to return `true` when NextToken exists - i.e. when the lastPage has not been reached

From the [docs](https://docs.aws.amazon.com/sdk-for-go/api/service/cloudwatchlogs/#CloudWatchLogs.FilterLogEventsPages)

```
To stop iterating, return false from the fn function
```

This change corrects code using Pages functions when the lastPage has not been reached.