### PR TITLE
add platform-version parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ GLOBAL OPTIONS:
    --log-group value, -l value    Cloudwatch Log Group Name to write logs to (default: "ecs-task-runner")
    --service value, -s value      service to replace cmd for
    --fargate                      Specified if task is to be run under FARGATE as opposed to EC2
+   --platform-version value       the platform version the task should run (only for FARGATE)
    --security-group value         Security groups to launch task in (required for FARGATE). Can be specified multiple times
    --subnet value                 Subnet to launch task in (required for FARGATE). Can be specified multiple times
    --env KEY=value, -e KEY=value  An environment variable to add in the form KEY=value or `KEY` (shorthand for `KEY=$KEY` to pass through an env var from the current host). Can be specified multiple times

--- a/main.go
+++ b/main.go
@@ -54,6 +54,11 @@ func main() {
 			Name:  "fargate",
 			Usage: "Specified if task is to be run under FARGATE as opposed to EC2",
 		},
+		&cli.StringFlag{
+			Name:  "platform-version, p",
+			Value: "",
+			Usage: "the platform version the task should run (only for FARGATE)",
+		},
 		&cli.StringSliceFlag{
 			Name:  "security-group",
 			Usage: "Security groups to launch task in (required for FARGATE). Can be specified multiple times",
@@ -102,6 +107,7 @@ func main() {
 		r.TaskName = ctx.String("name")
 		r.LogGroupName = ctx.String("log-group")
 		r.Fargate = ctx.Bool("fargate")
+		r.PlatformVersion = ctx.String("platform-version")
 		r.SecurityGroups = ctx.StringSlice("security-group")
 		r.Subnets = ctx.StringSlice("subnet")
 		r.Environment = ctx.StringSlice("env")

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -33,6 +33,7 @@ type Runner struct {
 	Cluster            string
 	LogGroupName       string
 	Region             string
+	PlatformVersion    string
 	Config             *aws.Config
 	Overrides          []Override
 	Fargate            bool
@@ -118,6 +119,9 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 	if r.Fargate {
 		runTaskInput.LaunchType = aws.String("FARGATE")
+		if len(r.PlatformVersion) > 0 {
+			runTaskInput.PlatformVersion = aws.String(r.PlatformVersion)
+		}
 	}
 	if len(r.Subnets) > 0 || len(r.SecurityGroups) > 0 {
 		runTaskInput.NetworkConfiguration = &ecs.NetworkConfiguration{


### PR DESCRIPTION
Adding `--platform-version` parameter to pass the Fargate platform version to RunTask. This allows to run a Fargate task on platform version `1.4.0` which is still not `LATEST`