### PR TITLE
feat: add platform-version CLI argument

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ steps:
     command: go test ./...
     plugins:
       - golang#v2.0.0:
-          version: 1.11.1
+          version: 1.16.2
           import: github.com/buildkite/ecs-run-task
           environment:
             - GO111MODULE=on
@@ -14,11 +14,11 @@ steps:
           build: "."
           import: github.com/buildkite/ecs-run-task
           targets:
-            - version: 1.11.1
+            - version: 1.16.2
               goos: linux
               goarch: amd64
               gomodule: "on"
-            - version: 1.11.1
+            - version: 1.16.2
               goos: windows
               goarch: amd64
               gomodule: "on"

--- a/main.go
+++ b/main.go
@@ -54,6 +54,10 @@ func main() {
 			Name:  "fargate",
 			Usage: "Specified if task is to be run under FARGATE as opposed to EC2",
 		},
+		&cli.StringFlag{
+			Name:  "platform-version",
+			Usage: "If using FARGATE, optionally specify the platform version to use",
+		},
 		&cli.StringSliceFlag{
 			Name:  "security-group",
 			Usage: "Security groups to launch task in (required for FARGATE). Can be specified multiple times",
@@ -102,6 +106,7 @@ func main() {
 		r.TaskName = ctx.String("name")
 		r.LogGroupName = ctx.String("log-group")
 		r.Fargate = ctx.Bool("fargate")
+		r.PlatformVersion = ctx.String("platform-version")
 		r.SecurityGroups = ctx.StringSlice("security-group")
 		r.Subnets = ctx.StringSlice("subnet")
 		r.Environment = ctx.StringSlice("env")

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -36,6 +36,7 @@ type Runner struct {
 	Config             *aws.Config
 	Overrides          []Override
 	Fargate            bool
+	PlatformVersion    string
 	SecurityGroups     []string
 	Subnets            []string
 	Environment        []string
@@ -118,6 +119,9 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 	if r.Fargate {
 		runTaskInput.LaunchType = aws.String("FARGATE")
+		if len(r.PlatformVersion) > 0 {
+			runTaskInput.PlatformVersion = aws.String(r.PlatformVersion)
+		}
 	}
 	if len(r.Subnets) > 0 || len(r.SecurityGroups) > 0 {
 		runTaskInput.NetworkConfiguration = &ecs.NetworkConfiguration{


### PR DESCRIPTION
ECS is still deploying to Fargate 1.3.0 by default. This is
pretty old, and is missing some very useful things.

This PR adds the ability to specify the platform version via
the new `--platform-version` argument. If specified, and if
the `--fargate` option has also been specified, the provided
platform version will be used to launch the task.

E.g.:

```
ecs-run-task --fargate --platform-version 1.4.0 ...
```