### PR TITLE
CI: upgrade to Go 1.16 from 1.11

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,10 +3,8 @@ steps:
     command: go test ./...
     plugins:
       - golang#v2.0.0:
-          version: 1.11.1
+          version: "1.16"
           import: github.com/buildkite/ecs-run-task
-          environment:
-            - GO111MODULE=on
 
   - label: "🛠"
     plugins:
@@ -14,11 +12,9 @@ steps:
           build: "."
           import: github.com/buildkite/ecs-run-task
           targets:
-            - version: 1.11.1
+            - version: "1.16"
               goos: linux
               goarch: amd64
-              gomodule: "on"
-            - version: 1.11.1
+            - version: "1.16"
               goos: windows
               goarch: amd64
-              gomodule: "on"


### PR DESCRIPTION
Multiple dependencies now require Go >= 1.11, so it will no longer build on the old version.

[Before](https://buildkite.com/buildkite/ecs-run-task/builds/10#88bc54c6-6619-4a8e-89de-137962db26a7):
```
[2021-05-13T04:09:51Z] go build github.com/cpuguy83/go-md2man/v2/md2man: module requires Go 1.12
[2021-05-13T04:09:55Z] go build github.com/buildkite/ecs-run-task/parser: module requires Go 1.13
[2021-05-13T04:09:58Z] FAIL	github.com/buildkite/ecs-run-task/runner [build failed]
```