### PR TITLE
Minor updates to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,25 +12,24 @@ USAGE:
    ecs-run-task [options] [command override]
 
 COMMANDS:
-     help, h  Shows a list of commands or help for one command
+   help, h  Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
-   --debug                        Show debugging information
-   --file value, -f value         Task definition file in JSON or YAML
-   --name value, -n value         Task name
-   --cluster value, -c value      ECS cluster name (default: "default")
-   --log-group value, -l value    Cloudwatch Log Group Name to write logs to (default: "ecs-task-runner")
-   --service value, -s value      service to replace cmd for
-   --fargate                      Specified if task is to be run under FARGATE as opposed to EC2
-   --security-group value         Security groups to launch task in (required for FARGATE). Can be specified multiple times
-   --subnet value                 Subnet to launch task in (required for FARGATE). Can be specified multiple times
-   --env KEY=value, -e KEY=value  An environment variable to add in the form KEY=value or `KEY` (shorthand for `KEY=$KEY` to pass through an env var from the current host). Can be specified multiple times
-   --inherit-env, -E              Inherit all of the environment variables from the calling shell
-   --count value, -C value        Number of tasks to run (default: 1)
-   --region value, -r value       AWS Region
-   --deregister                   Deregister task definition once done
-   --help, -h                     show help
-   --version, -v                  print the version
+   --debug                 Show debugging information (default: false)
+   --file value            Task definition file in JSON or YAML
+   --name value            Task name
+   --cluster value         ECS cluster name (default: "default")
+   --log-group value       Cloudwatch Log Group Name to write logs to (default: "ecs-task-runner")
+   --service value         service to replace cmd for
+   --fargate               Specified if task is to be run under FARGATE as opposed to EC2 (default: false)
+   --security-group value  Security groups to launch task in (required for FARGATE). Can be specified multiple times
+   --subnet value          Subnet to launch task in (required for FARGATE). Can be specified multiple times
+   --env KEY=value         An environment variable to add in the form KEY=value or `KEY` (shorthand for `KEY=$KEY` to pass through an env var from the current host). Can be specified multiple times
+   --inherit-env           Inherit all of the environment variables from the calling shell (default: false)
+   --count value           Number of tasks to run (default: 1)
+   --region value          AWS Region
+   --deregister            Deregister task definition once done (default: false)
+   --help, -h              show help (default: false)
 ```
 
 ### Example

--- a/README.md
+++ b/README.md
@@ -63,12 +63,3 @@ The following IAM permissions are required:
         - logs:FilterLogEvents
       Resource: '*'
 ```
-
-## Development
-
-We're using Go 1.11 with [modules](https://github.com/golang/go/wiki/Modules).
-
-```bash
-export GO111MODULE=on
-go get -u github.com/buildkite/ecs-run-task
-```


### PR DESCRIPTION
* Usage info regenerated from `ecs-run-task --help`.
* Remove old Go 1.11 / Go Modules references; assume modern Go in 2021 and beyond.